### PR TITLE
feat(auth): Implement Google Sign-In authentication

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -2,29 +2,44 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../features/auth/application/providers/auth_providers.dart';
+import '../features/auth/presentation/pages/login_page.dart';
+
 /// Router provider for the app
 final routerProvider = Provider<GoRouter>((ref) {
+  final authState = ref.watch(authNotifierProvider);
+
   return GoRouter(
-    initialLocation: '/',
+    initialLocation: '/login',
+    redirect: (context, state) {
+      final isLoggedIn = authState.valueOrNull != null;
+      final isLoggingIn = state.matchedLocation == '/login';
+
+      // If not logged in and not on login page, redirect to login
+      if (!isLoggedIn && !isLoggingIn) {
+        return '/login';
+      }
+
+      // If logged in and on login page, redirect to dashboard
+      if (isLoggedIn && isLoggingIn) {
+        return '/dashboard';
+      }
+
+      return null;
+    },
     routes: [
-      GoRoute(
-        path: '/',
-        name: 'home',
-        builder: (context, state) => const _PlaceholderScreen(
-          title: 'GigLedger',
-          message: 'Welcome to GigLedger!\nYour freelance business manager.',
-        ),
-      ),
       // Auth routes
       GoRoute(
         path: '/login',
         name: 'login',
-        builder: (context, state) => const _PlaceholderScreen(
-          title: 'Login',
-          message: 'Login screen coming soon',
-        ),
+        builder: (context, state) => const LoginPage(),
       ),
       // Dashboard routes
+      GoRoute(
+        path: '/',
+        name: 'home',
+        redirect: (context, state) => '/dashboard',
+      ),
       GoRoute(
         path: '/dashboard',
         name: 'dashboard',

--- a/lib/features/auth/application/providers/auth_providers.dart
+++ b/lib/features/auth/application/providers/auth_providers.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/data_sources/auth_remote_data_source.dart';
+import '../../data/repositories/auth_repository_impl.dart';
+import '../../domain/models/user_profile.dart';
+import '../../domain/repositories/i_auth_repository.dart';
+
+/// Provider for the auth remote data source
+final authRemoteDataSourceProvider = Provider<AuthRemoteDataSource>((ref) {
+  return AuthRemoteDataSourceImpl();
+});
+
+/// Provider for the auth repository
+final authRepositoryProvider = Provider<IAuthRepository>((ref) {
+  final dataSource = ref.watch(authRemoteDataSourceProvider);
+  return AuthRepositoryImpl(dataSource);
+});
+
+/// Stream provider for auth state changes
+/// Emits the current user profile or null when signed out
+final authStateProvider = StreamProvider<UserProfile?>((ref) {
+  final repository = ref.watch(authRepositoryProvider);
+  return repository.watchAuthState();
+});
+
+/// Provider for current user profile (async)
+final currentUserProvider = FutureProvider<UserProfile?>((ref) {
+  final repository = ref.watch(authRepositoryProvider);
+  return repository.getCurrentUser();
+});
+
+/// Auth state notifier for handling auth actions
+class AuthNotifier extends StateNotifier<AsyncValue<UserProfile?>> {
+  final IAuthRepository _repository;
+
+  AuthNotifier(this._repository) : super(const AsyncValue.loading()) {
+    _init();
+  }
+
+  Future<void> _init() async {
+    try {
+      final user = await _repository.getCurrentUser();
+      state = AsyncValue.data(user);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  /// Sign in with Google
+  Future<void> signInWithGoogle() async {
+    state = const AsyncValue.loading();
+    try {
+      final user = await _repository.signInWithGoogle();
+      state = AsyncValue.data(user);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+      rethrow;
+    }
+  }
+
+  /// Sign out
+  Future<void> signOut() async {
+    try {
+      await _repository.signOut();
+      state = const AsyncValue.data(null);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+      rethrow;
+    }
+  }
+
+  /// Update user profile
+  Future<void> updateProfile(UserProfile profile) async {
+    try {
+      final updated = await _repository.updateProfile(profile);
+      state = AsyncValue.data(updated);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+      rethrow;
+    }
+  }
+}
+
+/// Provider for auth notifier
+final authNotifierProvider =
+    StateNotifierProvider<AuthNotifier, AsyncValue<UserProfile?>>((ref) {
+  final repository = ref.watch(authRepositoryProvider);
+  return AuthNotifier(repository);
+});
+
+/// Convenience provider to check if user is signed in
+final isSignedInProvider = Provider<bool>((ref) {
+  final authState = ref.watch(authNotifierProvider);
+  return authState.valueOrNull != null;
+});

--- a/lib/features/auth/auth.dart
+++ b/lib/features/auth/auth.dart
@@ -4,3 +4,15 @@ library auth;
 // Domain
 export 'domain/models/user_profile.dart';
 export 'domain/repositories/i_auth_repository.dart';
+
+// Data
+export 'data/dto/user_profile_dto.dart';
+export 'data/data_sources/auth_remote_data_source.dart';
+export 'data/repositories/auth_repository_impl.dart';
+
+// Application
+export 'application/providers/auth_providers.dart';
+
+// Presentation
+export 'presentation/pages/login_page.dart';
+export 'presentation/widgets/google_sign_in_button.dart';

--- a/lib/features/auth/data/data_sources/auth_remote_data_source.dart
+++ b/lib/features/auth/data/data_sources/auth_remote_data_source.dart
@@ -1,0 +1,184 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+import '../../../../core/error/exceptions.dart';
+import '../dto/user_profile_dto.dart';
+
+/// Remote data source for authentication operations
+abstract class AuthRemoteDataSource {
+  /// Get the current Firebase user
+  User? get currentUser;
+
+  /// Stream of auth state changes
+  Stream<User?> get authStateChanges;
+
+  /// Sign in with Google
+  Future<UserProfileDTO> signInWithGoogle();
+
+  /// Sign out
+  Future<void> signOut();
+
+  /// Get user profile from Firestore
+  Future<UserProfileDTO?> getUserProfile(String uid);
+
+  /// Create or update user profile in Firestore
+  Future<UserProfileDTO> saveUserProfile(UserProfileDTO profile);
+}
+
+class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
+  final FirebaseAuth _firebaseAuth;
+  final FirebaseFirestore _firestore;
+  final GoogleSignIn _googleSignIn;
+
+  AuthRemoteDataSourceImpl({
+    FirebaseAuth? firebaseAuth,
+    FirebaseFirestore? firestore,
+    GoogleSignIn? googleSignIn,
+  })  : _firebaseAuth = firebaseAuth ?? FirebaseAuth.instance,
+        _firestore = firestore ?? FirebaseFirestore.instance,
+        _googleSignIn = googleSignIn ?? GoogleSignIn();
+
+  @override
+  User? get currentUser => _firebaseAuth.currentUser;
+
+  @override
+  Stream<User?> get authStateChanges => _firebaseAuth.authStateChanges();
+
+  @override
+  Future<UserProfileDTO> signInWithGoogle() async {
+    try {
+      // Trigger the Google Sign-In flow
+      final googleUser = await _googleSignIn.signIn();
+
+      if (googleUser == null) {
+        throw const AuthException(
+          'Google sign-in was cancelled',
+          code: 'sign-in-cancelled',
+        );
+      }
+
+      // Obtain the auth details from the request
+      final googleAuth = await googleUser.authentication;
+
+      // Create a new credential
+      final credential = GoogleAuthProvider.credential(
+        accessToken: googleAuth.accessToken,
+        idToken: googleAuth.idToken,
+      );
+
+      // Sign in to Firebase with the Google credential
+      final userCredential =
+          await _firebaseAuth.signInWithCredential(credential);
+
+      final user = userCredential.user;
+      if (user == null) {
+        throw const AuthException(
+          'Failed to sign in with Google',
+          code: 'sign-in-failed',
+        );
+      }
+
+      // Check if user profile exists, create if not
+      final existingProfile = await getUserProfile(user.uid);
+      if (existingProfile != null) {
+        // Update the profile with latest info from Google
+        return saveUserProfile(
+          UserProfileDTO(
+            id: user.uid,
+            email: user.email,
+            displayName: existingProfile.displayName ?? user.displayName,
+            businessName: existingProfile.businessName,
+            businessLogo: existingProfile.businessLogo,
+            businessAddress: existingProfile.businessAddress,
+            currency: existingProfile.currency,
+            taxRate: existingProfile.taxRate,
+            paymentInstructions: existingProfile.paymentInstructions,
+            createdAt: existingProfile.createdAt,
+            updatedAt: Timestamp.now(),
+          ),
+        );
+      }
+
+      // Create new profile for first-time users
+      final now = Timestamp.now();
+      return saveUserProfile(
+        UserProfileDTO(
+          id: user.uid,
+          email: user.email,
+          displayName: user.displayName,
+          currency: 'USD',
+          taxRate: 0,
+          createdAt: now,
+          updatedAt: now,
+        ),
+      );
+    } on FirebaseAuthException catch (e) {
+      throw AuthException(
+        e.message ?? 'Authentication failed',
+        code: e.code,
+      );
+    } on AuthException {
+      rethrow;
+    } catch (e) {
+      throw AuthException(
+        'Failed to sign in with Google: $e',
+        code: 'unknown',
+      );
+    }
+  }
+
+  @override
+  Future<void> signOut() async {
+    try {
+      await Future.wait([
+        _firebaseAuth.signOut(),
+        _googleSignIn.signOut(),
+      ]);
+    } catch (e) {
+      throw AuthException(
+        'Failed to sign out: $e',
+        code: 'sign-out-failed',
+      );
+    }
+  }
+
+  @override
+  Future<UserProfileDTO?> getUserProfile(String uid) async {
+    try {
+      final doc = await _firestore.collection('users').doc(uid).get();
+
+      if (!doc.exists || doc.data() == null) {
+        return null;
+      }
+
+      return UserProfileDTO.fromJson(doc.data()!, doc.id);
+    } catch (e) {
+      throw ServerException(
+        'Failed to get user profile: $e',
+        code: 'firestore-read-error',
+      );
+    }
+  }
+
+  @override
+  Future<UserProfileDTO> saveUserProfile(UserProfileDTO profile) async {
+    try {
+      final docRef = _firestore.collection('users').doc(profile.id);
+
+      await docRef.set(
+        profile.toJson(),
+        SetOptions(merge: true),
+      );
+
+      // Return the saved profile
+      final doc = await docRef.get();
+      return UserProfileDTO.fromJson(doc.data()!, doc.id);
+    } catch (e) {
+      throw ServerException(
+        'Failed to save user profile: $e',
+        code: 'firestore-write-error',
+      );
+    }
+  }
+}

--- a/lib/features/auth/data/dto/user_profile_dto.dart
+++ b/lib/features/auth/data/dto/user_profile_dto.dart
@@ -1,0 +1,96 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../domain/models/user_profile.dart';
+
+/// DTO for UserProfile matching Firestore document structure
+class UserProfileDTO {
+  final String? id;
+  final String? email;
+  final String? displayName;
+  final String? businessName;
+  final String? businessLogo;
+  final String? businessAddress;
+  final String? currency;
+  final double? taxRate;
+  final String? paymentInstructions;
+  final Timestamp? createdAt;
+  final Timestamp? updatedAt;
+
+  const UserProfileDTO({
+    this.id,
+    this.email,
+    this.displayName,
+    this.businessName,
+    this.businessLogo,
+    this.businessAddress,
+    this.currency,
+    this.taxRate,
+    this.paymentInstructions,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  factory UserProfileDTO.fromJson(Map<String, dynamic> json, String documentId) {
+    return UserProfileDTO(
+      id: documentId,
+      email: json['email'] as String?,
+      displayName: json['displayName'] as String?,
+      businessName: json['businessName'] as String?,
+      businessLogo: json['businessLogo'] as String?,
+      businessAddress: json['businessAddress'] as String?,
+      currency: json['currency'] as String?,
+      taxRate: (json['taxRate'] as num?)?.toDouble(),
+      paymentInstructions: json['paymentInstructions'] as String?,
+      createdAt: json['createdAt'] as Timestamp?,
+      updatedAt: json['updatedAt'] as Timestamp?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'email': email,
+      'displayName': displayName,
+      'businessName': businessName,
+      'businessLogo': businessLogo,
+      'businessAddress': businessAddress,
+      'currency': currency,
+      'taxRate': taxRate,
+      'paymentInstructions': paymentInstructions,
+      'createdAt': createdAt,
+      'updatedAt': updatedAt,
+    };
+  }
+
+  UserProfile toDomain() {
+    final now = DateTime.now();
+    return UserProfile(
+      id: id ?? '',
+      email: email ?? '',
+      displayName: displayName,
+      businessName: businessName,
+      businessLogo: businessLogo,
+      businessAddress: businessAddress,
+      currency: currency ?? 'USD',
+      taxRate: taxRate ?? 0.0,
+      paymentInstructions: paymentInstructions,
+      createdAt: createdAt?.toDate() ?? now,
+      updatedAt: updatedAt?.toDate() ?? now,
+    );
+  }
+
+  factory UserProfileDTO.fromDomain(UserProfile profile) {
+    return UserProfileDTO(
+      id: profile.id,
+      email: profile.email,
+      displayName: profile.displayName,
+      businessName: profile.businessName,
+      businessLogo: profile.businessLogo,
+      businessAddress: profile.businessAddress,
+      currency: profile.currency,
+      taxRate: profile.taxRate,
+      paymentInstructions: profile.paymentInstructions,
+      createdAt: Timestamp.fromDate(profile.createdAt),
+      updatedAt: Timestamp.fromDate(profile.updatedAt),
+    );
+  }
+}

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -1,0 +1,121 @@
+import '../../../../core/error/exceptions.dart';
+import '../../../../core/error/failures.dart';
+import '../../domain/models/user_profile.dart';
+import '../../domain/repositories/i_auth_repository.dart';
+import '../data_sources/auth_remote_data_source.dart';
+import '../dto/user_profile_dto.dart';
+
+/// Implementation of IAuthRepository using Firebase
+class AuthRepositoryImpl implements IAuthRepository {
+  final AuthRemoteDataSource _dataSource;
+
+  AuthRepositoryImpl(this._dataSource);
+
+  @override
+  Future<UserProfile?> getCurrentUser() async {
+    final user = _dataSource.currentUser;
+    if (user == null) {
+      return null;
+    }
+
+    try {
+      final dto = await _dataSource.getUserProfile(user.uid);
+      return dto?.toDomain();
+    } on ServerException {
+      return null;
+    }
+  }
+
+  @override
+  Stream<UserProfile?> watchAuthState() {
+    return _dataSource.authStateChanges.asyncMap((user) async {
+      if (user == null) {
+        return null;
+      }
+
+      try {
+        final dto = await _dataSource.getUserProfile(user.uid);
+        return dto?.toDomain();
+      } catch (e) {
+        return null;
+      }
+    });
+  }
+
+  @override
+  Future<UserProfile> signInWithGoogle() async {
+    try {
+      final dto = await _dataSource.signInWithGoogle();
+      return dto.toDomain();
+    } on AuthException catch (e) {
+      throw AuthFailure(e.message, code: e.code);
+    } on ServerException catch (e) {
+      throw ServerFailure(e.message, code: e.code);
+    }
+  }
+
+  @override
+  Future<UserProfile> signInWithApple() async {
+    // TODO: Implement in Apple Sign-In issue #2
+    throw const AuthFailure(
+      'Apple Sign-In not implemented yet',
+      code: 'not-implemented',
+    );
+  }
+
+  @override
+  Future<UserProfile> signInWithEmail(String email, String password) async {
+    // TODO: Implement in Email Sign-In issue #3
+    throw const AuthFailure(
+      'Email Sign-In not implemented yet',
+      code: 'not-implemented',
+    );
+  }
+
+  @override
+  Future<UserProfile> createAccount(String email, String password) async {
+    // TODO: Implement in Email Sign-In issue #3
+    throw const AuthFailure(
+      'Account creation not implemented yet',
+      code: 'not-implemented',
+    );
+  }
+
+  @override
+  Future<void> sendPasswordReset(String email) async {
+    // TODO: Implement in Email Sign-In issue #3
+    throw const AuthFailure(
+      'Password reset not implemented yet',
+      code: 'not-implemented',
+    );
+  }
+
+  @override
+  Future<UserProfile> updateProfile(UserProfile profile) async {
+    try {
+      final dto = UserProfileDTO.fromDomain(profile);
+      final savedDto = await _dataSource.saveUserProfile(dto);
+      return savedDto.toDomain();
+    } on ServerException catch (e) {
+      throw ServerFailure(e.message, code: e.code);
+    }
+  }
+
+  @override
+  Future<void> signOut() async {
+    try {
+      await _dataSource.signOut();
+    } on AuthException catch (e) {
+      throw AuthFailure(e.message, code: e.code);
+    }
+  }
+
+  @override
+  Future<void> deleteAccount() async {
+    // TODO: Implement account deletion
+    throw const AuthFailure(
+      'Account deletion not implemented yet',
+      code: 'not-implemented',
+    );
+  }
+}

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/error/failures.dart';
+import '../../application/providers/auth_providers.dart';
+import '../widgets/google_sign_in_button.dart';
+
+/// Login page with authentication options
+class LoginPage extends ConsumerStatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  ConsumerState<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends ConsumerState<LoginPage> {
+  bool _isLoading = false;
+  String? _errorMessage;
+
+  Future<void> _signInWithGoogle() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      await ref.read(authNotifierProvider.notifier).signInWithGoogle();
+      if (mounted) {
+        context.go('/dashboard');
+      }
+    } on AuthFailure catch (e) {
+      if (mounted) {
+        setState(() {
+          _errorMessage = e.message;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _errorMessage = 'An unexpected error occurred. Please try again.';
+        });
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Spacer(flex: 2),
+              // App logo and branding
+              Icon(
+                Icons.account_balance_wallet,
+                size: 80,
+                color: theme.colorScheme.primary,
+              ),
+              const SizedBox(height: 24),
+              Text(
+                'GigLedger',
+                textAlign: TextAlign.center,
+                style: theme.textTheme.headlineLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Your freelance business manager',
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const Spacer(flex: 2),
+              // Error message
+              if (_errorMessage != null) ...[
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.errorContainer,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(
+                        Icons.error_outline,
+                        color: theme.colorScheme.onErrorContainer,
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Text(
+                          _errorMessage!,
+                          style: TextStyle(
+                            color: theme.colorScheme.onErrorContainer,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 16),
+              ],
+              // Sign in buttons
+              GoogleSignInButton(
+                onPressed: _signInWithGoogle,
+                isLoading: _isLoading,
+              ),
+              const SizedBox(height: 12),
+              // Apple Sign-In button placeholder (for issue #2)
+              SizedBox(
+                width: double.infinity,
+                height: 48,
+                child: OutlinedButton.icon(
+                  onPressed: () {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Apple Sign-In coming soon'),
+                      ),
+                    );
+                  },
+                  style: OutlinedButton.styleFrom(
+                    backgroundColor: Colors.black,
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                  icon: const Icon(Icons.apple, size: 24),
+                  label: const Text(
+                    'Continue with Apple',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+              // Divider with "or"
+              Row(
+                children: [
+                  const Expanded(child: Divider()),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Text(
+                      'or',
+                      style: TextStyle(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                  const Expanded(child: Divider()),
+                ],
+              ),
+              const SizedBox(height: 24),
+              // Email sign-in button placeholder (for issue #3)
+              SizedBox(
+                width: double.infinity,
+                height: 48,
+                child: OutlinedButton.icon(
+                  onPressed: () {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Email Sign-In coming soon'),
+                      ),
+                    );
+                  },
+                  style: OutlinedButton.styleFrom(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                  icon: const Icon(Icons.email_outlined),
+                  label: const Text(
+                    'Continue with Email',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ),
+              const Spacer(),
+              // Terms and privacy
+              Text(
+                'By continuing, you agree to our Terms of Service and Privacy Policy',
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/widgets/google_sign_in_button.dart
+++ b/lib/features/auth/presentation/widgets/google_sign_in_button.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+
+/// Google Sign-In button following Google's brand guidelines
+class GoogleSignInButton extends StatelessWidget {
+  final VoidCallback? onPressed;
+  final bool isLoading;
+
+  const GoogleSignInButton({
+    super.key,
+    this.onPressed,
+    this.isLoading = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 48,
+      child: OutlinedButton(
+        onPressed: isLoading ? null : onPressed,
+        style: OutlinedButton.styleFrom(
+          backgroundColor: Colors.white,
+          foregroundColor: Colors.black87,
+          side: const BorderSide(color: Color(0xFFDADCE0)),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
+        ),
+        child: isLoading
+            ? const SizedBox(
+                height: 24,
+                width: 24,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  // Google "G" logo
+                  Container(
+                    height: 24,
+                    width: 24,
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: CustomPaint(
+                      painter: _GoogleLogoPainter(),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  const Text(
+                    'Continue with Google',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+}
+
+/// Custom painter for the Google "G" logo
+class _GoogleLogoPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final double width = size.width;
+    final double height = size.height;
+    final double centerX = width / 2;
+    final double centerY = height / 2;
+
+    // Draw the Google "G" using paths
+    final Paint bluePaint = Paint()..color = const Color(0xFF4285F4);
+    final Paint greenPaint = Paint()..color = const Color(0xFF34A853);
+    final Paint yellowPaint = Paint()..color = const Color(0xFFFBBC05);
+    final Paint redPaint = Paint()..color = const Color(0xFFEA4335);
+
+    // Simplified "G" representation
+    final double radius = width * 0.4;
+
+    // Blue arc (right side)
+    canvas.drawArc(
+      Rect.fromCircle(center: Offset(centerX, centerY), radius: radius),
+      -0.5,
+      1.6,
+      true,
+      bluePaint,
+    );
+
+    // Green arc (bottom right)
+    canvas.drawArc(
+      Rect.fromCircle(center: Offset(centerX, centerY), radius: radius),
+      1.1,
+      1.0,
+      true,
+      greenPaint,
+    );
+
+    // Yellow arc (bottom left)
+    canvas.drawArc(
+      Rect.fromCircle(center: Offset(centerX, centerY), radius: radius),
+      2.1,
+      1.0,
+      true,
+      yellowPaint,
+    );
+
+    // Red arc (top)
+    canvas.drawArc(
+      Rect.fromCircle(center: Offset(centerX, centerY), radius: radius),
+      3.1,
+      1.1,
+      true,
+      redPaint,
+    );
+
+    // White center circle
+    canvas.drawCircle(
+      Offset(centerX, centerY),
+      radius * 0.55,
+      Paint()..color = Colors.white,
+    );
+
+    // Blue horizontal bar
+    canvas.drawRect(
+      Rect.fromLTWH(
+        centerX,
+        centerY - radius * 0.2,
+        radius * 0.85,
+        radius * 0.4,
+      ),
+      bluePaint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}


### PR DESCRIPTION
## Summary

- Implement complete Google Sign-In authentication flow following Clean Architecture
- Create user profiles in Firestore on first sign-in, update on subsequent sign-ins
- Add auth-aware routing with automatic redirects based on auth state
- Build login page with Google Sign-In button following brand guidelines

## Changes

### Data Layer
- `UserProfileDTO` - Firestore serialization with `fromJson`, `toJson`, `toDomain`, `fromDomain`
- `AuthRemoteDataSource` - Firebase Auth + Firestore operations for Google Sign-In

### Repository
- `AuthRepositoryImpl` - Implements `IAuthRepository`, transforms DTOs to domain models

### Application Layer
- Riverpod providers: `authNotifierProvider`, `authStateProvider`, `currentUserProvider`
- `AuthNotifier` - StateNotifier for auth actions (signIn, signOut, updateProfile)

### Presentation
- `LoginPage` - Authentication screen with social sign-in options
- `GoogleSignInButton` - Custom button with Google "G" logo

### Router
- Auth-aware redirect logic
- Redirects unauthenticated users to login
- Redirects authenticated users from login to dashboard

## Test plan

- [ ] Build passes (`flutter build apk --debug` verified)
- [ ] Google Sign-In flow creates user profile in Firestore
- [ ] Existing users get profile updated on sign-in
- [ ] Auth state persists across app restarts
- [ ] Unauthenticated users redirected to login
- [ ] Authenticated users redirected to dashboard

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)