### PR TITLE
ci: Make Claude review run after build checks pass

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,19 +3,34 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "lib/**/*.dart"
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
 
 jobs:
-  claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+  # Run build checks first - if these fail, Claude review won't run
+  build-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.24.0'
+          channel: 'stable'
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Analyze code
+        run: flutter analyze --no-fatal-infos
+
+      - name: Run tests
+        run: flutter test --no-pub
+
+  # Claude review only runs if build-check passes
+  claude-review:
+    needs: build-check
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Add `build-check` job that runs Flutter analyze and tests first
- Claude review now depends on build-check via `needs: build-check`
- Claude review only kicks off if build checks pass

## Rationale

This saves API costs by not running expensive Claude reviews on PRs that would fail basic build/test checks anyway. If analyze or tests fail, the PR author can fix those issues first before getting a Claude review.

## Test plan

- [x] Verify workflow syntax is valid
- [ ] Open a test PR to confirm job ordering works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)