### PR TITLE
feat(auth): Implement email/password sign-in (#3)

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../features/auth/application/providers/auth_providers.dart';
+import '../features/auth/presentation/pages/email_sign_in_page.dart';
 import '../features/auth/presentation/pages/login_page.dart';
 import '../features/clients/presentation/pages/client_list_page.dart';
 import '../features/expenses/presentation/pages/expense_list_page.dart';
@@ -17,15 +18,16 @@ final routerProvider = Provider<GoRouter>((ref) {
     initialLocation: '/login',
     redirect: (context, state) {
       final isLoggedIn = authState.valueOrNull != null;
-      final isLoggingIn = state.matchedLocation == '/login';
+      final isOnAuthPage = state.matchedLocation == '/login' ||
+          state.matchedLocation == '/email-sign-in';
 
-      // If not logged in and not on login page, redirect to login
-      if (!isLoggedIn && !isLoggingIn) {
+      // If not logged in and not on an auth page, redirect to login
+      if (!isLoggedIn && !isOnAuthPage) {
         return '/login';
       }
 
-      // If logged in and on login page, redirect to dashboard
-      if (isLoggedIn && isLoggingIn) {
+      // If logged in and on an auth page, redirect to dashboard
+      if (isLoggedIn && isOnAuthPage) {
         return '/dashboard';
       }
 
@@ -37,6 +39,11 @@ final routerProvider = Provider<GoRouter>((ref) {
         path: '/login',
         name: 'login',
         builder: (context, state) => const LoginPage(),
+      ),
+      GoRoute(
+        path: '/email-sign-in',
+        name: 'email-sign-in',
+        builder: (context, state) => const EmailSignInPage(),
       ),
 
       // Main app shell with bottom navigation

--- a/lib/features/auth/application/providers/auth_providers.dart
+++ b/lib/features/auth/application/providers/auth_providers.dart
@@ -58,6 +58,39 @@ class AuthNotifier extends StateNotifier<AsyncValue<UserProfile?>> {
     }
   }
 
+  /// Sign in with email and password
+  Future<void> signInWithEmail(String email, String password) async {
+    state = const AsyncValue.loading();
+    try {
+      final user = await _repository.signInWithEmail(email, password);
+      state = AsyncValue.data(user);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+      rethrow;
+    }
+  }
+
+  /// Create account with email and password
+  Future<void> createAccount(String email, String password) async {
+    state = const AsyncValue.loading();
+    try {
+      final user = await _repository.createAccount(email, password);
+      state = AsyncValue.data(user);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+      rethrow;
+    }
+  }
+
+  /// Send password reset email
+  Future<void> sendPasswordReset(String email) async {
+    try {
+      await _repository.sendPasswordReset(email);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
   /// Sign out
   Future<void> signOut() async {
     try {

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -65,29 +65,35 @@ class AuthRepositoryImpl implements IAuthRepository {
 
   @override
   Future<UserProfile> signInWithEmail(String email, String password) async {
-    // TODO: Implement in Email Sign-In issue #3
-    throw const AuthFailure(
-      'Email Sign-In not implemented yet',
-      code: 'not-implemented',
-    );
+    try {
+      final dto = await _dataSource.signInWithEmail(email, password);
+      return dto.toDomain();
+    } on AuthException catch (e) {
+      throw AuthFailure(e.message, code: e.code);
+    } on ServerException catch (e) {
+      throw ServerFailure(e.message, code: e.code);
+    }
   }
 
   @override
   Future<UserProfile> createAccount(String email, String password) async {
-    // TODO: Implement in Email Sign-In issue #3
-    throw const AuthFailure(
-      'Account creation not implemented yet',
-      code: 'not-implemented',
-    );
+    try {
+      final dto = await _dataSource.createAccountWithEmail(email, password);
+      return dto.toDomain();
+    } on AuthException catch (e) {
+      throw AuthFailure(e.message, code: e.code);
+    } on ServerException catch (e) {
+      throw ServerFailure(e.message, code: e.code);
+    }
   }
 
   @override
   Future<void> sendPasswordReset(String email) async {
-    // TODO: Implement in Email Sign-In issue #3
-    throw const AuthFailure(
-      'Password reset not implemented yet',
-      code: 'not-implemented',
-    );
+    try {
+      await _dataSource.sendPasswordResetEmail(email);
+    } on AuthException catch (e) {
+      throw AuthFailure(e.message, code: e.code);
+    }
   }
 
   @override

--- a/lib/features/auth/presentation/pages/email_sign_in_page.dart
+++ b/lib/features/auth/presentation/pages/email_sign_in_page.dart
@@ -1,0 +1,397 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/error/failures.dart';
+import '../../application/providers/auth_providers.dart';
+
+/// Email sign-in page with sign in and sign up tabs
+class EmailSignInPage extends ConsumerStatefulWidget {
+  const EmailSignInPage({super.key});
+
+  @override
+  ConsumerState<EmailSignInPage> createState() => _EmailSignInPageState();
+}
+
+class _EmailSignInPageState extends ConsumerState<EmailSignInPage>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  final _signInFormKey = GlobalKey<FormState>();
+  final _signUpFormKey = GlobalKey<FormState>();
+
+  // Sign In controllers
+  final _signInEmailController = TextEditingController();
+  final _signInPasswordController = TextEditingController();
+
+  // Sign Up controllers
+  final _signUpEmailController = TextEditingController();
+  final _signUpPasswordController = TextEditingController();
+  final _signUpConfirmPasswordController = TextEditingController();
+
+  bool _isLoading = false;
+  bool _obscureSignInPassword = true;
+  bool _obscureSignUpPassword = true;
+  bool _obscureConfirmPassword = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    _signInEmailController.dispose();
+    _signInPasswordController.dispose();
+    _signUpEmailController.dispose();
+    _signUpPasswordController.dispose();
+    _signUpConfirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  String? _validateEmail(String? value) {
+    if (value == null || value.isEmpty) {
+      return 'Email is required';
+    }
+    final emailRegex = RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$');
+    if (!emailRegex.hasMatch(value)) {
+      return 'Enter a valid email address';
+    }
+    return null;
+  }
+
+  String? _validatePassword(String? value) {
+    if (value == null || value.isEmpty) {
+      return 'Password is required';
+    }
+    if (value.length < 8) {
+      return 'Password must be at least 8 characters';
+    }
+    return null;
+  }
+
+  String? _validateConfirmPassword(String? value) {
+    if (value == null || value.isEmpty) {
+      return 'Please confirm your password';
+    }
+    if (value != _signUpPasswordController.text) {
+      return 'Passwords do not match';
+    }
+    return null;
+  }
+
+  Future<void> _handleSignIn() async {
+    if (!_signInFormKey.currentState!.validate()) return;
+
+    setState(() => _isLoading = true);
+
+    try {
+      await ref.read(authNotifierProvider.notifier).signInWithEmail(
+            _signInEmailController.text.trim(),
+            _signInPasswordController.text,
+          );
+      // Navigation will happen automatically via auth state
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(_getErrorMessage(e)),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  Future<void> _handleSignUp() async {
+    if (!_signUpFormKey.currentState!.validate()) return;
+
+    setState(() => _isLoading = true);
+
+    try {
+      await ref.read(authNotifierProvider.notifier).createAccount(
+            _signUpEmailController.text.trim(),
+            _signUpPasswordController.text,
+          );
+      // Navigation will happen automatically via auth state
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(_getErrorMessage(e)),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  Future<void> _handleForgotPassword() async {
+    final email = _signInEmailController.text.trim();
+    if (email.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Enter your email address first'),
+        ),
+      );
+      return;
+    }
+
+    if (_validateEmail(email) != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Enter a valid email address'),
+        ),
+      );
+      return;
+    }
+
+    setState(() => _isLoading = true);
+
+    try {
+      await ref.read(authNotifierProvider.notifier).sendPasswordReset(email);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Password reset email sent. Check your inbox.'),
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(_getErrorMessage(e)),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  String _getErrorMessage(Object error) {
+    if (error is AuthFailure) {
+      return error.message;
+    }
+    return 'An error occurred. Please try again.';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.pop(),
+        ),
+        title: const Text('Continue with Email'),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'Sign In'),
+            Tab(text: 'Sign Up'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          _buildSignInTab(theme),
+          _buildSignUpTab(theme),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSignInTab(ThemeData theme) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Form(
+        key: _signInFormKey,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _signInEmailController,
+              keyboardType: TextInputType.emailAddress,
+              textInputAction: TextInputAction.next,
+              autocorrect: false,
+              decoration: const InputDecoration(
+                labelText: 'Email',
+                hintText: 'Enter your email',
+                prefixIcon: Icon(Icons.email_outlined),
+                border: OutlineInputBorder(),
+              ),
+              validator: _validateEmail,
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _signInPasswordController,
+              obscureText: _obscureSignInPassword,
+              textInputAction: TextInputAction.done,
+              onFieldSubmitted: (_) => _handleSignIn(),
+              decoration: InputDecoration(
+                labelText: 'Password',
+                hintText: 'Enter your password',
+                prefixIcon: const Icon(Icons.lock_outlined),
+                border: const OutlineInputBorder(),
+                suffixIcon: IconButton(
+                  icon: Icon(
+                    _obscureSignInPassword
+                        ? Icons.visibility_outlined
+                        : Icons.visibility_off_outlined,
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      _obscureSignInPassword = !_obscureSignInPassword;
+                    });
+                  },
+                ),
+              ),
+              validator: _validatePassword,
+            ),
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: _isLoading ? null : _handleForgotPassword,
+                child: const Text('Forgot Password?'),
+              ),
+            ),
+            const SizedBox(height: 24),
+            FilledButton(
+              onPressed: _isLoading ? null : _handleSignIn,
+              style: FilledButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+              ),
+              child: _isLoading
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Sign In'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSignUpTab(ThemeData theme) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Form(
+        key: _signUpFormKey,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _signUpEmailController,
+              keyboardType: TextInputType.emailAddress,
+              textInputAction: TextInputAction.next,
+              autocorrect: false,
+              decoration: const InputDecoration(
+                labelText: 'Email',
+                hintText: 'Enter your email',
+                prefixIcon: Icon(Icons.email_outlined),
+                border: OutlineInputBorder(),
+              ),
+              validator: _validateEmail,
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _signUpPasswordController,
+              obscureText: _obscureSignUpPassword,
+              textInputAction: TextInputAction.next,
+              decoration: InputDecoration(
+                labelText: 'Password',
+                hintText: 'At least 8 characters',
+                prefixIcon: const Icon(Icons.lock_outlined),
+                border: const OutlineInputBorder(),
+                suffixIcon: IconButton(
+                  icon: Icon(
+                    _obscureSignUpPassword
+                        ? Icons.visibility_outlined
+                        : Icons.visibility_off_outlined,
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      _obscureSignUpPassword = !_obscureSignUpPassword;
+                    });
+                  },
+                ),
+              ),
+              validator: _validatePassword,
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _signUpConfirmPasswordController,
+              obscureText: _obscureConfirmPassword,
+              textInputAction: TextInputAction.done,
+              onFieldSubmitted: (_) => _handleSignUp(),
+              decoration: InputDecoration(
+                labelText: 'Confirm Password',
+                hintText: 'Re-enter your password',
+                prefixIcon: const Icon(Icons.lock_outlined),
+                border: const OutlineInputBorder(),
+                suffixIcon: IconButton(
+                  icon: Icon(
+                    _obscureConfirmPassword
+                        ? Icons.visibility_outlined
+                        : Icons.visibility_off_outlined,
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      _obscureConfirmPassword = !_obscureConfirmPassword;
+                    });
+                  },
+                ),
+              ),
+              validator: _validateConfirmPassword,
+            ),
+            const SizedBox(height: 24),
+            FilledButton(
+              onPressed: _isLoading ? null : _handleSignUp,
+              style: FilledButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+              ),
+              child: _isLoading
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Create Account'),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'By creating an account, you agree to our Terms of Service and Privacy Policy.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -167,18 +167,12 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                 ],
               ),
               const SizedBox(height: 24),
-              // Email sign-in button placeholder (for issue #3)
+              // Email sign-in button
               SizedBox(
                 width: double.infinity,
                 height: 48,
                 child: OutlinedButton.icon(
-                  onPressed: () {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(
-                        content: Text('Email Sign-In coming soon'),
-                      ),
-                    );
-                  },
+                  onPressed: () => context.push('/email-sign-in'),
                   style: OutlinedButton.styleFrom(
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(8),


### PR DESCRIPTION
## Summary
- Add email/password sign-in with Firebase Auth
- Add account creation with email/password
- Add password reset functionality via email
- Form validation for email format and password strength (8+ chars)
- User-friendly error messages for Firebase auth errors

## Test plan
- [ ] Sign in with existing email/password account
- [ ] Create new account with email/password
- [ ] Verify password validation (8+ chars required)
- [ ] Test password reset flow
- [ ] Verify error messages display correctly

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)