### PR TITLE
feat(settings): Add sign out button (#40)

### DIFF
--- a/lib/features/settings/presentation/pages/business_profile_page.dart
+++ b/lib/features/settings/presentation/pages/business_profile_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
+import '../../../auth/application/providers/auth_providers.dart';
 import '../../application/providers/settings_providers.dart';
 import '../widgets/currency_selector.dart';
 import '../widgets/logo_upload_widget.dart';
@@ -164,6 +166,45 @@ class _BusinessProfilePageState extends ConsumerState<BusinessProfilePage> {
             backgroundColor: Theme.of(context).colorScheme.error,
           ),
         );
+      }
+    }
+  }
+
+  Future<void> _handleSignOut() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Sign Out'),
+        content: const Text('Are you sure you want to sign out?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Sign Out'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && mounted) {
+      try {
+        await ref.read(authNotifierProvider.notifier).signOut();
+        if (mounted) {
+          context.go('/login');
+        }
+      } catch (e) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Failed to sign out: $e'),
+              behavior: SnackBarBehavior.floating,
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+          );
+        }
       }
     }
   }
@@ -341,6 +382,21 @@ class _BusinessProfilePageState extends ConsumerState<BusinessProfilePage> {
                             : const Text('Save Changes'),
                       ),
                     ),
+                  const SizedBox(height: 32),
+                  const Divider(),
+                  const SizedBox(height: 16),
+
+                  // Sign out button
+                  OutlinedButton.icon(
+                    onPressed: _handleSignOut,
+                    icon: const Icon(Icons.logout),
+                    label: const Text('Sign Out'),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: theme.colorScheme.error,
+                      side: BorderSide(color: theme.colorScheme.error),
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                    ),
+                  ),
                   const SizedBox(height: 32),
                 ],
               ),


### PR DESCRIPTION
## Summary
- Add sign out button to Business Profile/Settings page
- Confirmation dialog before signing out
- Redirects to login page after successful sign out

## Test plan
- [ ] Sign out button visible at bottom of Settings page
- [ ] Confirmation dialog appears when tapped
- [ ] Cancel returns to settings
- [ ] Confirm signs out and redirects to login
- [ ] Works after signing in with Google
- [ ] Works after signing in with Email

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)