### PR TITLE
feat(security): Implement Firestore security rules (#29)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,1 +1,35 @@
-{"flutter":{"platforms":{"android":{"default":{"projectId":"gigledger-app","appId":"1:1019634697825:android:5b6774207e50758c6f8c20","fileOutput":"android/app/google-services.json"}},"ios":{"default":{"projectId":"gigledger-app","appId":"1:1019634697825:ios:2d8a4d8ca2fbdf606f8c20","uploadDebugSymbols":false,"fileOutput":"ios/Runner/GoogleService-Info.plist"}},"dart":{"lib/firebase_options.dart":{"projectId":"gigledger-app","configurations":{"android":"1:1019634697825:android:5b6774207e50758c6f8c20","ios":"1:1019634697825:ios:2d8a4d8ca2fbdf606f8c20","web":"1:1019634697825:web:4ee5807df4d3f2116f8c20"}}}}}}
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "flutter": {
+    "platforms": {
+      "android": {
+        "default": {
+          "projectId": "gigledger-app",
+          "appId": "1:1019634697825:android:5b6774207e50758c6f8c20",
+          "fileOutput": "android/app/google-services.json"
+        }
+      },
+      "ios": {
+        "default": {
+          "projectId": "gigledger-app",
+          "appId": "1:1019634697825:ios:2d8a4d8ca2fbdf606f8c20",
+          "uploadDebugSymbols": false,
+          "fileOutput": "ios/Runner/GoogleService-Info.plist"
+        }
+      },
+      "dart": {
+        "lib/firebase_options.dart": {
+          "projectId": "gigledger-app",
+          "configurations": {
+            "android": "1:1019634697825:android:5b6774207e50758c6f8c20",
+            "ios": "1:1019634697825:ios:2d8a4d8ca2fbdf606f8c20",
+            "web": "1:1019634697825:web:4ee5807df4d3f2116f8c20"
+          }
+        }
+      }
+    }
+  }
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,159 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // ============================================
+    // HELPER FUNCTIONS
+    // ============================================
+
+    // Check if request has valid authentication
+    function isAuthenticated() {
+      return request.auth != null;
+    }
+
+    // Check if authenticated user owns the resource (uid matches)
+    function isOwner(uid) {
+      return isAuthenticated() && request.auth.uid == uid;
+    }
+
+    // Check if a field exists and is a non-empty string
+    function isNonEmptyString(field) {
+      return field is string && field.size() > 0;
+    }
+
+    // Check if a field is a valid timestamp
+    function isValidTimestamp(field) {
+      return field is timestamp;
+    }
+
+    // Check if a field is a valid number (including 0)
+    function isValidNumber(field) {
+      return field is number;
+    }
+
+    // ============================================
+    // USER PROFILES: /users/{uid}
+    // ============================================
+    match /users/{uid} {
+      // Users can only read their own profile
+      allow read: if isOwner(uid);
+
+      // Users can create their own profile
+      // Required: email, currency, createdAt, updatedAt
+      allow create: if isOwner(uid)
+                    && request.resource.data.keys().hasAll(['email', 'currency', 'createdAt', 'updatedAt'])
+                    && isNonEmptyString(request.resource.data.email)
+                    && isNonEmptyString(request.resource.data.currency)
+                    && isValidTimestamp(request.resource.data.createdAt)
+                    && isValidTimestamp(request.resource.data.updatedAt);
+
+      // Users can update their own profile
+      // Cannot change createdAt (immutable)
+      allow update: if isOwner(uid)
+                    && request.resource.data.createdAt == resource.data.createdAt
+                    && isValidTimestamp(request.resource.data.updatedAt);
+
+      // Users can delete their own profile
+      allow delete: if isOwner(uid);
+
+      // ============================================
+      // CLIENTS: /users/{uid}/clients/{clientId}
+      // ============================================
+      match /clients/{clientId} {
+        // Users can read their own clients
+        allow read: if isOwner(uid);
+
+        // Users can create clients
+        // Required: userId (must match auth), name, createdAt, updatedAt
+        allow create: if isOwner(uid)
+                      && request.resource.data.userId == request.auth.uid
+                      && isNonEmptyString(request.resource.data.name)
+                      && isValidTimestamp(request.resource.data.createdAt)
+                      && isValidTimestamp(request.resource.data.updatedAt);
+
+        // Users can update their own clients
+        // Cannot change userId or createdAt
+        allow update: if isOwner(uid)
+                      && request.resource.data.userId == resource.data.userId
+                      && request.resource.data.createdAt == resource.data.createdAt
+                      && isValidTimestamp(request.resource.data.updatedAt);
+
+        // Users can delete their own clients
+        allow delete: if isOwner(uid);
+      }
+
+      // ============================================
+      // EXPENSES: /users/{uid}/expenses/{expenseId}
+      // ============================================
+      match /expenses/{expenseId} {
+        // Users can read their own expenses
+        allow read: if isOwner(uid);
+
+        // Users can create expenses
+        // Required: userId (must match auth), amount, category, date, createdAt, updatedAt
+        allow create: if isOwner(uid)
+                      && request.resource.data.userId == request.auth.uid
+                      && isValidNumber(request.resource.data.amount)
+                      && isNonEmptyString(request.resource.data.category)
+                      && isValidTimestamp(request.resource.data.date)
+                      && isValidTimestamp(request.resource.data.createdAt)
+                      && isValidTimestamp(request.resource.data.updatedAt);
+
+        // Users can update their own expenses
+        // Cannot change userId or createdAt
+        allow update: if isOwner(uid)
+                      && request.resource.data.userId == resource.data.userId
+                      && request.resource.data.createdAt == resource.data.createdAt
+                      && isValidTimestamp(request.resource.data.updatedAt);
+
+        // Users can delete their own expenses
+        allow delete: if isOwner(uid);
+      }
+
+      // ============================================
+      // INVOICES: /users/{uid}/invoices/{invoiceId}
+      // ============================================
+      match /invoices/{invoiceId} {
+        // Users can read their own invoices
+        allow read: if isOwner(uid);
+
+        // Users can create invoices
+        // Required: userId (must match auth), clientId, status, createdAt, updatedAt
+        allow create: if isOwner(uid)
+                      && request.resource.data.userId == request.auth.uid
+                      && isNonEmptyString(request.resource.data.clientId)
+                      && isNonEmptyString(request.resource.data.status)
+                      && isValidTimestamp(request.resource.data.createdAt)
+                      && isValidTimestamp(request.resource.data.updatedAt);
+
+        // Users can update their own invoices
+        // Cannot change userId or createdAt
+        allow update: if isOwner(uid)
+                      && request.resource.data.userId == resource.data.userId
+                      && request.resource.data.createdAt == resource.data.createdAt
+                      && isValidTimestamp(request.resource.data.updatedAt);
+
+        // Users can delete their own invoices
+        allow delete: if isOwner(uid);
+      }
+    }
+
+    // ============================================
+    // INVOICE TEMPLATES: /invoiceTemplates/{templateId}
+    // Read-only for all authenticated users
+    // ============================================
+    match /invoiceTemplates/{templateId} {
+      allow read: if isAuthenticated();
+      allow write: if false; // Only admins via Firebase Console
+    }
+
+    // ============================================
+    // DEFAULT DENY
+    // All other paths are denied by default
+    // ============================================
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `firestore.rules` with comprehensive security rules
- Users can only read/write their own data under `/users/{uid}/...`
- Field validation for required fields on create
- Immutable field protection (userId, createdAt)
- Default deny for unknown collections
- Invoice templates are read-only for authenticated users

## Security Features
- **User isolation** - Users cannot access other users' data
- **Field validation** - Required fields enforced on create
- **Tamper protection** - userId and createdAt cannot be modified
- **Default deny** - Unknown paths blocked by default

## Collections Covered
- `/users/{uid}` - User profiles
- `/users/{uid}/clients/{clientId}` - Clients
- `/users/{uid}/expenses/{expenseId}` - Expenses
- `/users/{uid}/invoices/{invoiceId}` - Invoices
- `/invoiceTemplates/{templateId}` - Read-only templates

## Test plan
- [ ] User can read/write own profile
- [ ] User can CRUD own clients/expenses
- [ ] User cannot read another user's data
- [ ] Required field validation works
- [ ] userId/createdAt cannot be modified

## Deployment
After merge, deploy rules:
```bash
firebase deploy --only firestore:rules
```

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)