### PR TITLE
feat(storage): Add Firebase Storage security rules

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -3,6 +3,9 @@
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
   },
+  "storage": {
+    "rules": "storage.rules"
+  },
   "flutter": {
     "platforms": {
       "android": {

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,40 @@
+rules_version = '2';
+
+service firebase.storage {
+  match /b/{bucket}/o {
+
+    // Helper function to check authentication
+    function isAuthenticated() {
+      return request.auth != null;
+    }
+
+    // Helper function to check if user owns the path
+    function isOwner(uid) {
+      return isAuthenticated() && request.auth.uid == uid;
+    }
+
+    // Helper function to validate image uploads
+    function isValidImage() {
+      return request.resource.contentType.matches('image/.*')
+             && request.resource.size < 5 * 1024 * 1024; // Max 5MB
+    }
+
+    // User-specific storage paths
+    // Pattern: /users/{uid}/...
+    match /users/{uid}/{allPaths=**} {
+      // Users can read their own files
+      allow read: if isOwner(uid);
+
+      // Users can write their own files (with validation)
+      allow write: if isOwner(uid) && isValidImage();
+
+      // Users can delete their own files
+      allow delete: if isOwner(uid);
+    }
+
+    // Default deny for all other paths
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds Firebase Storage security rules to enable secure file uploads (logo, receipts).

- Creates `storage.rules` with user-scoped access control
- Users can only read/write files in their own `/users/{uid}/` path
- Validates uploads are images under 5MB
- Updates `firebase.json` to include storage rules configuration

## Changes

- `storage.rules` (new): Security rules for Firebase Storage
- `firebase.json`: Added storage rules reference

## Test Plan

- [x] Deploy rules with `firebase deploy --only storage`
- [x] Test logo upload in Business Profile settings
- [x] Verify upload succeeds with valid image
- [x] Verify other users cannot access uploaded files

🤖 Generated with [Claude Code](https://claude.com/claude-code)