### PR TITLE
fix: Prevent Firebase duplicate initialization on hot restart

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,9 +8,12 @@ import 'firebase_options.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
+  // Only initialize Firebase if not already initialized (prevents hot restart errors)
+  if (Firebase.apps.isEmpty) {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  }
 
   runApp(
     const ProviderScope(


### PR DESCRIPTION
## Problem

Hot restart causes Firebase error:
```
Unhandled Exception: [core/duplicate-app] A Firebase App named "[DEFAULT]" already exists
```

## Solution

Check `Firebase.apps.isEmpty` before calling `initializeApp()`. This prevents re-initialization when the app restarts but Firebase is already initialized.

## Test plan

1. Run the app with `flutter run`
2. Make a code change
3. Press `r` for hot restart
4. Verify no Firebase duplicate-app error appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)