### PR TITLE
feat: Add Expense by Category Report with pie chart

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -14,6 +14,7 @@ import '../features/expenses/presentation/pages/expense_list_page.dart';
 import '../features/invoices/presentation/pages/invoice_detail_page.dart';
 import '../features/invoices/presentation/pages/invoice_form_page.dart';
 import '../features/invoices/presentation/pages/invoice_list_page.dart';
+import '../features/reports/presentation/pages/expense_category_report_page.dart';
 import '../features/reports/presentation/pages/income_expense_report_page.dart';
 import '../features/reports/presentation/pages/top_clients_report_page.dart';
 import '../features/settings/presentation/pages/business_profile_page.dart';
@@ -202,6 +203,11 @@ final routerProvider = Provider<GoRouter>((ref) {
         path: '/reports/top-clients',
         name: 'top-clients-report',
         builder: (context, state) => const TopClientsReportPage(),
+      ),
+      GoRoute(
+        path: '/reports/expenses-by-category',
+        name: 'expense-category-report',
+        builder: (context, state) => const ExpenseCategoryReportPage(),
       ),
 
       // Root redirect

--- a/lib/features/reports/presentation/pages/income_expense_report_page.dart
+++ b/lib/features/reports/presentation/pages/income_expense_report_page.dart
@@ -33,6 +33,8 @@ class IncomeExpenseReportPage extends ConsumerWidget {
             onSelected: (value) {
               if (value == 'top-clients') {
                 context.push('/reports/top-clients');
+              } else if (value == 'expense-category') {
+                context.push('/reports/expenses-by-category');
               }
             },
             itemBuilder: (context) => [
@@ -41,6 +43,14 @@ class IncomeExpenseReportPage extends ConsumerWidget {
                 child: ListTile(
                   leading: Icon(Icons.people),
                   title: Text('Top Clients'),
+                  contentPadding: EdgeInsets.zero,
+                ),
+              ),
+              const PopupMenuItem(
+                value: 'expense-category',
+                child: ListTile(
+                  leading: Icon(Icons.pie_chart),
+                  title: Text('Expenses by Category'),
                   contentPadding: EdgeInsets.zero,
                 ),
               ),

--- a/lib/features/reports/reports.dart
+++ b/lib/features/reports/reports.dart
@@ -12,5 +12,6 @@ export 'data/repositories/reports_repository_impl.dart';
 export 'application/providers/reports_providers.dart';
 
 // Presentation
+export 'presentation/pages/expense_category_report_page.dart';
 export 'presentation/pages/income_expense_report_page.dart';
 export 'presentation/pages/top_clients_report_page.dart';


### PR DESCRIPTION
## Summary
- Adds Expense by Category Report accessible at `/reports/expenses-by-category`
- Date range picker with presets (This Month, Last Month, Last 3/6 Months, Year to Date, Custom)
- Summary card showing total expenses and category count
- Pie chart showing spending distribution (top 5 categories, others grouped)
- Category table with icons, amounts, and percentages
- Tap any category row to navigate to expenses list filtered by that category
- All three reports now have cross-navigation via the ⋮ menu

## Test plan
- [ ] Open reports via Dashboard → View Reports
- [ ] Navigate to Expenses by Category via ⋮ menu
- [ ] Test date range presets
- [ ] Verify pie chart shows category distribution
- [ ] Verify table shows all categories with correct amounts
- [ ] Tap a category row to verify it navigates to filtered expenses list

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)