### PR TITLE
feat: Send invoice via device email app

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1253,6 +1253,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.28"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: cfde38aa257dae62ffe79c87fab20165dfdf6988c1d31b58ebf59b9106062aad
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.6"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   uuid:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   path_provider: ^2.1.5
   path: ^1.9.0
   fl_chart: ^1.1.1
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

- Adds ability to send invoices via the device's native email app using url_launcher
- Pre-fills recipient email, subject, and a formatted invoice body
- Shows confirmation dialog after user returns from email app to update invoice status

## Changes

- Added `url_launcher` package (6.3.2) to pubspec.yaml
- Modified `invoice_detail_page.dart`:
  - Added `_buildEmailBody()` method to generate formatted invoice email content
  - Updated `_sendInvoice()` to open native email app with mailto: URI
  - Added confirmation dialog that prompts user to mark invoice as "Sent"
  - Added proper error handling and loading states

## Test Plan

- [ ] Open an invoice in Draft status
- [ ] Tap "Send" button
- [ ] Verify email app opens with pre-filled recipient, subject, and body
- [ ] Return to app and verify confirmation dialog appears
- [ ] Tap "Yes, Mark as Sent" and verify invoice status changes to "Sent"
- [ ] Test "Not Yet" option - status should remain unchanged

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)